### PR TITLE
ci: add ci checker

### DIFF
--- a/.github/workflows/commit-checker.yaml
+++ b/.github/workflows/commit-checker.yaml
@@ -1,0 +1,12 @@
+name: Conventional Commits Check
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  clober-template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: webiny/action-conventional-commits@v1.1.0

--- a/.github/workflows/pr-checker.yaml
+++ b/.github/workflows/pr-checker.yaml
@@ -1,0 +1,20 @@
+name: Pull Request Description Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+# Action should have write permission to make updates to PR
+permissions:
+  pull-requests: write
+
+jobs:
+  clober-template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mtfoley/pr-compliance-action@main
+        with:
+          body-regex: '.{10,}'
+          body-fail: true
+          body-comment: 'Please provide a description of your PR.'
+          title-check-enable: false


### PR DESCRIPTION
## Features

This pull request adds a checker for pull requests that does the following:
1. Enforces a pull request description. If the description is empty, the pull request will be automatically closed.
2. Checks for conventional commits.

These changes will help ensure that all pull requests have a clear description and follow a consistent commit message format.